### PR TITLE
Revert "Bump org.jetbrains.dokka from 0.10.1 to 0.11.0-dev-59"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'signing'
-    id 'org.jetbrains.dokka' version '0.11.0-dev-59'
+    id 'org.jetbrains.dokka' version '0.10.1'
     id "io.codearte.nexus-staging" version "0.21.2"
 }
 


### PR DESCRIPTION
Reverts KogeLabs/Koge#6

A problem occurred configuring root project 'ockero'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jetbrains.dokka:dokka-core:0.11.0-dev-59.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-core/0.11.0-dev-59/dokka-core-0.11.0-dev-59.pom
     Required by:
         project : > org.je